### PR TITLE
merge: conflict 해결

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -9,3 +9,4 @@ class CustomUser(AbstractUser):
     email = models.EmailField(unique=True)
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = []
+    is_first_login = models.BooleanField(default=True)

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import kakao_token_view, user_info_view, register_view, login_view, update_profile_view
+from .views import kakao_token_view, user_info_view, register_view, login_view, update_profile_view, complete_preference_view
 from .views import CustomTokenRefreshView
 
 urlpatterns = [
@@ -10,4 +10,5 @@ urlpatterns = [
     path('token/refresh/', CustomTokenRefreshView.as_view(), name='token_refresh'),
     path('update-profile/', update_profile_view),
     path('user-info/', user_info_view, name='user-info'),
+    path('complete-preference/', complete_preference_view, name='complete-preference'),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -52,6 +52,8 @@ def kakao_token_view(request):
         'message': '카카오 로그인 성공',
         'access': tokens['access'],
         'refresh': tokens['refresh'],
+        'user_id': user.id, # 추가
+        'is_first_login': user.is_first_login  # 추가
     })
 
 
@@ -106,7 +108,8 @@ def login_view(request):
             'message': '로그인 성공',
             'access': tokens['access'],
             'refresh': tokens['refresh'],
-            'user_id': user.id
+            'user_id': user.id,
+            'is_first_login': user.is_first_login  # 추가
         })
     return Response(serializer.errors, status=400)
 
@@ -140,3 +143,12 @@ def update_profile_view(request):
         'nickname': user.nickname,
         'profile_image_url': user.profile_image.url if user.profile_image else None
     })
+    return Response({'message': '프로필이 업데이트 되었습니다.'})
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def complete_preference_view(request):
+    user = request.user
+    user.is_first_login = False
+    user.save()
+    return Response({'message': '취향 분석 완료 처리됨'})


### PR DESCRIPTION
- CustomUser 모델에 is_first_login 필드(BooleanField, 기본값 True) 추가 -> 첫 로그인 시에만 취향 분석 질문 뜨도록 함

- /accounts/login/ 및 /accounts/kakao-login/ 응답에 is_first_login 값 포함

- /accounts/complete-preference/ 사용자가 취향 선택 완료 시 호출하는 api -> 호출 시 is_first_login=False로 변경 -> 다음 로그인부터 취향분석 질문 안 뜸